### PR TITLE
feat: restore player position on startup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,8 +112,7 @@ function App() {
         if (tid !== undefined && tid !== null) {
           try {
             const track = await invoke<Track>("get_track_by_id", { trackId: tid });
-            playback.setCurrentTrack(track);
-            if (pos) playback.setPositionSecs(pos);
+            await playback.handleRestore(track, pos ?? 0);
           } catch {
             // Track was deleted
           }
@@ -425,6 +424,7 @@ function App() {
           <input
             type="text"
             placeholder={
+              view === "history" ? "Search history..." :
               view === "artists" && selectedArtist === null ? "Search artists..." :
               view === "albums" && selectedAlbum === null ? "Search albums..." :
               view === "tags" && selectedTag === null ? "Search tags..." :
@@ -726,7 +726,7 @@ function App() {
 
           {/* History view */}
           {view === "history" && (
-            <HistoryView onPlayTrack={queueHook.playTracks} />
+            <HistoryView searchQuery={searchQuery} onPlayTrack={queueHook.playTracks} />
           )}
         </div>
       </main>

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -61,6 +61,10 @@ export function Breadcrumb({
           <span className="breadcrumb-sep"> {"\u203A"} </span>
           <span>{albums.find(a => a.id === selectedAlbum)?.title ?? "Album"}</span>
         </>
+      ) : view === "liked" ? (
+        <span>Liked Tracks</span>
+      ) : view === "history" ? (
+        <span>History</span>
       ) : (
         <span>All Tracks</span>
       )}

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { Track, PlayHistoryEntry, MostPlayedTrack } from "../types";
 
 interface HistoryViewProps {
+  searchQuery: string;
   onPlayTrack: (tracks: Track[], index: number) => void;
 }
 
@@ -23,7 +24,12 @@ function formatDuration(secs: number | null): string {
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
-export function HistoryView({ onPlayTrack }: HistoryViewProps) {
+function matchesQuery(q: string, title: string, artist: string | null): boolean {
+  const lower = q.toLowerCase();
+  return title.toLowerCase().includes(lower) || (artist?.toLowerCase().includes(lower) ?? false);
+}
+
+export function HistoryView({ searchQuery, onPlayTrack }: HistoryViewProps) {
   const [mostPlayedAllTime, setMostPlayedAllTime] = useState<MostPlayedTrack[]>([]);
   const [mostPlayedRecent, setMostPlayedRecent] = useState<MostPlayedTrack[]>([]);
   const [recentPlays, setRecentPlays] = useState<PlayHistoryEntry[]>([]);
@@ -41,6 +47,15 @@ export function HistoryView({ onPlayTrack }: HistoryViewProps) {
     }).catch(console.error);
   }, []);
 
+  const q = searchQuery.trim();
+  const filteredAllTime = mostPlayedAllTime
+    .map((t, i) => ({ ...t, rank: i + 1 }))
+    .filter(t => !q || matchesQuery(q, t.track_title, t.artist_name));
+  const filteredRecent30 = mostPlayedRecent
+    .map((t, i) => ({ ...t, rank: i + 1 }))
+    .filter(t => !q || matchesQuery(q, t.track_title, t.artist_name));
+  const filteredPlays = q ? recentPlays.filter(t => matchesQuery(q, t.track_title, t.artist_name)) : recentPlays;
+
   async function handleClick(trackId: number) {
     try {
       const track = await invoke<Track>("get_track_by_id", { trackId });
@@ -52,13 +67,13 @@ export function HistoryView({ onPlayTrack }: HistoryViewProps) {
 
   return (
     <div className="history-view">
-      {mostPlayedAllTime.length > 0 && (
+      {filteredAllTime.length > 0 && (
         <div className="history-section">
           <div className="section-title">Most Played — All Time</div>
           <div className="history-list">
-            {mostPlayedAllTime.map((t, i) => (
+            {filteredAllTime.map((t) => (
               <div key={t.track_id} className="history-row" onClick={() => handleClick(t.track_id)}>
-                <span className="history-rank">{i + 1}</span>
+                <span className="history-rank">{t.rank}</span>
                 <div className="history-info">
                   <span className="history-title">{t.track_title}</span>
                   <span className="history-artist">{t.artist_name ?? "Unknown"}</span>
@@ -71,13 +86,13 @@ export function HistoryView({ onPlayTrack }: HistoryViewProps) {
         </div>
       )}
 
-      {mostPlayedRecent.length > 0 && (
+      {filteredRecent30.length > 0 && (
         <div className="history-section">
           <div className="section-title">Most Played — Last 30 Days</div>
           <div className="history-list">
-            {mostPlayedRecent.map((t, i) => (
+            {filteredRecent30.map((t) => (
               <div key={t.track_id} className="history-row" onClick={() => handleClick(t.track_id)}>
-                <span className="history-rank">{i + 1}</span>
+                <span className="history-rank">{t.rank}</span>
                 <div className="history-info">
                   <span className="history-title">{t.track_title}</span>
                   <span className="history-artist">{t.artist_name ?? "Unknown"}</span>
@@ -93,7 +108,7 @@ export function HistoryView({ onPlayTrack }: HistoryViewProps) {
       <div className="history-section">
         <div className="section-title">Recent History</div>
         <div className="history-list">
-          {recentPlays.map((entry) => (
+          {filteredPlays.map((entry) => (
             <div key={entry.id} className="history-row" onClick={() => handleClick(entry.track_id)}>
               <span className="history-time">{formatRelativeTime(entry.played_at)}</span>
               <div className="history-info">
@@ -103,7 +118,7 @@ export function HistoryView({ onPlayTrack }: HistoryViewProps) {
               <span className="history-duration">{formatDuration(entry.duration_secs)}</span>
             </div>
           ))}
-          {recentPlays.length === 0 && (
+          {filteredPlays.length === 0 && (
             <div className="empty">No play history yet. Start listening to build your history.</div>
           )}
         </div>

--- a/src/hooks/usePlayback.ts
+++ b/src/hooks/usePlayback.ts
@@ -14,6 +14,8 @@ export function usePlayback(restoredRef: React.RefObject<boolean>) {
   const audioRef = useRef<HTMLAudioElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const pendingSrcRef = useRef<string | null>(null);
+  const pendingAutoPlayRef = useRef(true);
+  const pendingSeekRef = useRef(0);
 
   function getMediaElement(): HTMLAudioElement | HTMLVideoElement | null {
     if (currentTrack && isVideoTrack(currentTrack)) {
@@ -28,14 +30,21 @@ export function usePlayback(restoredRef: React.RefObject<boolean>) {
     if (videoRef.current) videoRef.current.volume = volume;
   }, [volume]);
 
-  // Start video playback once the element is available after render
+  // Load video source once the element is available after render
   useEffect(() => {
     if (pendingSrcRef.current && currentTrack && isVideoTrack(currentTrack) && videoRef.current) {
       const src = pendingSrcRef.current;
+      const autoPlay = pendingAutoPlayRef.current;
       pendingSrcRef.current = null;
+      pendingAutoPlayRef.current = true;
+      const seekTo = pendingSeekRef.current;
+      pendingSeekRef.current = 0;
       videoRef.current.src = src;
       videoRef.current.volume = volume;
-      videoRef.current.play().catch(e => console.error("Video play error:", e));
+      if (seekTo > 0) videoRef.current.currentTime = seekTo;
+      if (autoPlay) {
+        videoRef.current.play().catch(e => console.error("Video play error:", e));
+      }
     }
   }, [currentTrack]);
 
@@ -97,6 +106,39 @@ export function usePlayback(restoredRef: React.RefObject<boolean>) {
     }
   }
 
+  async function handleRestore(track: Track, position: number) {
+    try {
+      const pathOrUrl = await invoke<string>("get_track_path", { trackId: track.id });
+      const src = track.subsonic_id ? pathOrUrl : convertFileSrc(pathOrUrl);
+
+      setCurrentTrack(track);
+      setPositionSecs(position);
+      setDurationSecs(track.duration_secs ?? 0);
+
+      const loadInto = (el: HTMLMediaElement) => {
+        el.src = src;
+        el.volume = volume;
+        el.currentTime = position;
+      };
+
+      if (isVideoTrack(track)) {
+        if (videoRef.current) {
+          loadInto(videoRef.current);
+        } else {
+          pendingSrcRef.current = src;
+          pendingAutoPlayRef.current = false;
+          pendingSeekRef.current = position;
+        }
+      } else {
+        if (audioRef.current) {
+          loadInto(audioRef.current);
+        }
+      }
+    } catch (e) {
+      console.error("Restore error:", e);
+    }
+  }
+
   function handleStop() {
     const el = getMediaElement();
     if (el) {
@@ -141,7 +183,7 @@ export function usePlayback(restoredRef: React.RefObject<boolean>) {
     volume, setVolume,
     audioRef, videoRef,
     getMediaElement,
-    handlePlay, handlePause, handleStop,
+    handlePlay, handlePause, handleStop, handleRestore,
     handleVolume, handleSeek,
     onTimeUpdate, onLoadedMetadata, onPlay, onPause,
   };


### PR DESCRIPTION
## Summary
- Load the media source and seek to the saved position on app restore, so the player starts paused and ready to resume
- Add search filtering to the history view (most played, recent plays)
- Add breadcrumb labels for liked and history views

## Test plan
- [ ] Play a track partway, close the app, reopen — player should show the track paused at the last position
- [ ] Click play to verify it resumes from the saved position
- [ ] Test with video tracks as well
- [ ] Verify history view search filtering works

🤖 Generated with [Claude Code](https://claude.com/claude-code)