### PR TITLE
fix: add missing allAlbumsRef declaration in useLibrary

### DIFF
--- a/src/hooks/useLibrary.ts
+++ b/src/hooks/useLibrary.ts
@@ -34,6 +34,7 @@ export function useLibrary(restoredRef: React.RefObject<boolean>, onBeforeNaviga
   const [loadingMore, setLoadingMore] = useState(false);
   const PAGE_SIZE = 100;
   const tracksRef = useRef<Track[]>([]);
+  const allAlbumsRef = useRef<Album[]>([]);
 
   // Sort state
   const [sortField, setSortField] = useState<SortField | null>(null);


### PR DESCRIPTION
## Summary
- Added missing `allAlbumsRef` declaration in `useLibrary.ts` — the ref was used but never declared, causing a runtime `ReferenceError` that prevented the entire app from rendering

## Test plan
- [x] `npx tsc --noEmit` passes clean
- [x] App launches and renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)