### PR TITLE
feat: enable multi-select in playlist

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2429,6 +2429,12 @@ body {
   padding-left: 13px;
 }
 
+.queue-item.selected {
+  background: rgba(83, 168, 255, 0.15);
+  border-left: 3px solid var(--accent);
+  padding-left: 13px;
+}
+
 .queue-item-info {
   flex: 1;
   min-width: 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -745,6 +745,9 @@ function App() {
       const idSet = new Set(target.trackIds);
       const selected = sortedTracks.filter(t => idSet.has(t.id));
       if (selected.length > 0) queueHook.playTracks(selected, 0);
+    } else if (target.kind === "queue-multi") {
+      const selected = target.indices.map(i => queueHook.queue[i]).filter(Boolean);
+      if (selected.length > 0) queueHook.playTracks(selected, 0);
     }
   }
 
@@ -765,6 +768,21 @@ function App() {
       const selected = sortedTracks.filter(t => idSet.has(t.id));
       queueHook.enqueueTracks(selected);
     }
+  }
+
+  function handleQueueRemove() {
+    if (!contextMenu || contextMenu.target.kind !== "queue-multi") return;
+    queueHook.removeMultiple(contextMenu.target.indices);
+  }
+
+  function handleQueueMoveToTop() {
+    if (!contextMenu || contextMenu.target.kind !== "queue-multi") return;
+    queueHook.moveToTop(contextMenu.target.indices);
+  }
+
+  function handleQueueMoveToBottom() {
+    if (!contextMenu || contextMenu.target.kind !== "queue-multi") return;
+    queueHook.moveToBottom(contextMenu.target.indices);
   }
 
   function handleShowInFolder() {
@@ -1645,6 +1663,9 @@ function App() {
           onClose={() => queueHook.setShowQueue(false)}
           onSavePlaylist={queueHook.savePlaylist}
           onLoadPlaylist={queueHook.loadPlaylist}
+          onContextMenu={(e, indices) => {
+            setContextMenu({ x: e.clientX, y: e.clientY, target: { kind: "queue-multi", indices } });
+          }}
         />
       )}
 
@@ -1657,6 +1678,9 @@ function App() {
           onShowInFolder={handleShowInFolder}
           onWatchOnYoutube={handleWatchOnYoutube}
           onShowProperties={handleShowProperties}
+          onRemoveFromQueue={handleQueueRemove}
+          onMoveToTop={handleQueueMoveToTop}
+          onMoveToBottom={handleQueueMoveToBottom}
           onClose={() => setContextMenu(null)}
         />
       )}

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -8,7 +8,8 @@ export type ContextMenuTarget =
   | { kind: "track"; trackId: number; subsonic: boolean; title: string; artistName: string | null }
   | { kind: "album"; albumId: number; title: string; artistName: string | null }
   | { kind: "artist"; artistId: number; name: string }
-  | { kind: "multi-track"; trackIds: number[] };
+  | { kind: "multi-track"; trackIds: number[] }
+  | { kind: "queue-multi"; indices: number[] };
 
 export interface ContextMenuState {
   x: number;
@@ -24,6 +25,9 @@ interface ContextMenuProps {
   onShowInFolder: () => void;
   onWatchOnYoutube?: () => void;
   onShowProperties?: () => void;
+  onRemoveFromQueue?: () => void;
+  onMoveToTop?: () => void;
+  onMoveToBottom?: () => void;
   onClose: () => void;
 }
 
@@ -67,19 +71,48 @@ function ProviderIcon({ provider }: { provider: SearchProviderConfig }) {
 }
 
 export function ContextMenu({
-  menu, providers, onPlay, onEnqueue, onShowInFolder, onWatchOnYoutube, onShowProperties, onClose,
+  menu, providers, onPlay, onEnqueue, onShowInFolder, onWatchOnYoutube, onShowProperties,
+  onRemoveFromQueue, onMoveToTop, onMoveToBottom, onClose,
 }: ContextMenuProps) {
   const { target } = menu;
 
   const isMulti = target.kind === "multi-track";
-  const context = isMulti ? "track" : target.kind;
-  const contextProviders = isMulti ? [] : getProvidersForContext(providers, context);
+  const isQueue = target.kind === "queue-multi";
+  const context = isMulti || isQueue ? "track" : target.kind;
+  const contextProviders = isMulti || isQueue ? [] : getProvidersForContext(providers, context);
   const urlKey = context === "artist" ? "artistUrl" : context === "album" ? "albumUrl" : "trackUrl";
 
-  const params = isMulti ? {} :
+  const params = isMulti || isQueue ? {} :
     target.kind === "artist"
       ? { artist: target.name }
       : { title: target.title, artist: target.artistName ?? undefined };
+
+  const count = isQueue ? target.indices.length : isMulti ? target.trackIds.length : 1;
+
+  if (isQueue) {
+    return (
+      <div className="context-menu" style={{ top: menu.y, left: menu.x }}>
+        <div className="context-menu-item" onClick={() => { onPlay(); onClose(); }}>
+          <IconPlay size={14} /><span>{count > 1 ? `Play ${count} tracks` : "Play"}</span>
+        </div>
+        {onRemoveFromQueue && (
+          <div className="context-menu-item" onClick={() => { onRemoveFromQueue(); onClose(); }}>
+            <IconFolder size={14} /><span>{count > 1 ? `Remove ${count} tracks` : "Remove"}</span>
+          </div>
+        )}
+        {onMoveToTop && (
+          <div className="context-menu-item" onClick={() => { onMoveToTop(); onClose(); }}>
+            <IconEnqueue size={14} /><span>Move to top</span>
+          </div>
+        )}
+        {onMoveToBottom && (
+          <div className="context-menu-item" onClick={() => { onMoveToBottom(); onClose(); }}>
+            <IconEnqueue size={14} /><span>Move to bottom</span>
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/components/QueuePanel.tsx
+++ b/src/components/QueuePanel.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useEffect } from "react";
 import type { Track } from "../types";
 import { formatDuration } from "../utils";
 
@@ -7,6 +8,37 @@ function formatTotalDuration(tracks: Track[]): string {
   const mins = Math.floor((totalSecs % 3600) / 60);
   if (hours > 0) return `${hours}h ${mins}m`;
   return `${mins}m`;
+}
+
+function computeIndexSelection(
+  current: Set<number>,
+  clickedIndex: number,
+  lastIndex: number | null,
+  meta: boolean,
+  shift: boolean,
+): Set<number> {
+  if (shift) {
+    const start = lastIndex ?? 0;
+    const lo = Math.min(start, clickedIndex);
+    const hi = Math.max(start, clickedIndex);
+    const range = new Set(Array.from({ length: hi - lo + 1 }, (_, k) => lo + k));
+    if (meta) {
+      const merged = new Set(current);
+      for (const idx of range) merged.add(idx);
+      return merged;
+    }
+    return range;
+  }
+  if (meta) {
+    const next = new Set(current);
+    if (next.has(clickedIndex)) {
+      next.delete(clickedIndex);
+    } else {
+      next.add(clickedIndex);
+    }
+    return next;
+  }
+  return new Set([clickedIndex]);
 }
 
 interface QueuePanelProps {
@@ -22,14 +54,55 @@ interface QueuePanelProps {
   onClose: () => void;
   onSavePlaylist: () => void;
   onLoadPlaylist: () => void;
+  onContextMenu: (e: React.MouseEvent, indices: number[]) => void;
 }
 
 export function QueuePanel({
   queue, queueIndex, queuePanelRef, dragIndexRef, playlistName,
-  onPlay, onRemove, onMove, onClear, onClose, onSavePlaylist, onLoadPlaylist,
+  onPlay, onRemove, onMove, onClear, onClose, onSavePlaylist, onLoadPlaylist, onContextMenu,
 }: QueuePanelProps) {
+  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
+  const lastClickedIndexRef = useRef<number | null>(null);
+
+  // Clear selection when queue changes (add/remove/reorder)
+  useEffect(() => { setSelectedIndices(new Set()); }, [queue]);
+
+  function handleClick(e: React.MouseEvent, track: Track, index: number) {
+    const meta = e.metaKey || e.ctrlKey;
+    const shift = e.shiftKey;
+
+    const newSelection = computeIndexSelection(
+      selectedIndices, index,
+      lastClickedIndexRef.current, meta, shift,
+    );
+    setSelectedIndices(newSelection);
+    lastClickedIndexRef.current = index;
+
+    // Only play on plain click (no modifiers)
+    if (!meta && !shift) {
+      onPlay(track, index);
+    }
+  }
+
+  function handleContextMenu(e: React.MouseEvent, index: number) {
+    e.preventDefault();
+    if (selectedIndices.size > 1 && selectedIndices.has(index)) {
+      onContextMenu(e, [...selectedIndices].sort((a, b) => a - b));
+    } else {
+      setSelectedIndices(new Set([index]));
+      lastClickedIndexRef.current = index;
+      onContextMenu(e, [index]);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      setSelectedIndices(new Set());
+    }
+  }
+
   return (
-    <aside className="queue-panel" ref={queuePanelRef}>
+    <aside className="queue-panel" ref={queuePanelRef} tabIndex={-1} onKeyDown={handleKeyDown}>
       <div className="queue-header">
         <span className="queue-title">Playlist</span>
         <div className="queue-header-actions">
@@ -43,7 +116,7 @@ export function QueuePanel({
         {queue.map((t, i) => (
           <div
             key={`${t.id}-${i}`}
-            className={`queue-item ${i === queueIndex ? "queue-current" : ""}`}
+            className={`queue-item${i === queueIndex ? " queue-current" : ""}${selectedIndices.has(i) ? " selected" : ""}`}
             draggable
             onDragStart={() => { dragIndexRef.current = i; }}
             onDragOver={(e) => { e.preventDefault(); }}
@@ -53,7 +126,8 @@ export function QueuePanel({
               }
               dragIndexRef.current = null;
             }}
-            onClick={() => onPlay(t, i)}
+            onClick={(e) => handleClick(e, t, i)}
+            onContextMenu={(e) => handleContextMenu(e, i)}
           >
             <div className="queue-item-info">
               <span className="queue-item-title">{t.title}</span>

--- a/src/hooks/useQueue.ts
+++ b/src/hooks/useQueue.ts
@@ -164,6 +164,47 @@ export function useQueue(
     });
   }
 
+  function removeMultiple(indices: number[]) {
+    const toRemove = new Set(indices);
+    setQueue(prev => prev.filter((_, i) => !toRemove.has(i)));
+    setQueueIndex(prev => {
+      if (toRemove.has(prev)) return Math.max(0, prev - [...toRemove].filter(i => i < prev).length);
+      return prev - [...toRemove].filter(i => i < prev).length;
+    });
+  }
+
+  function moveToTop(indices: number[]) {
+    const sorted = [...indices].sort((a, b) => a - b);
+    setQueue(prev => {
+      const moving = sorted.map(i => prev[i]);
+      const remaining = prev.filter((_, i) => !new Set(sorted).has(i));
+      return [...moving, ...remaining];
+    });
+    setQueueIndex(prev => {
+      const indexSet = new Set(sorted);
+      if (indexSet.has(prev)) return sorted.indexOf(prev);
+      const shiftedBefore = sorted.filter(i => i < prev).length;
+      return prev - shiftedBefore + sorted.length;
+    });
+  }
+
+  function moveToBottom(indices: number[]) {
+    const sorted = [...indices].sort((a, b) => a - b);
+    setQueue(prev => {
+      const moving = sorted.map(i => prev[i]);
+      const remaining = prev.filter((_, i) => !new Set(sorted).has(i));
+      return [...remaining, ...moving];
+    });
+    setQueueIndex(prev => {
+      const indexSet = new Set(sorted);
+      if (indexSet.has(prev)) {
+        const remaining = queue.length - sorted.length;
+        return remaining + sorted.indexOf(prev);
+      }
+      return prev - sorted.filter(i => i < prev).length;
+    });
+  }
+
   function moveInQueue(from: number, to: number) {
     setQueue(prev => {
       const next = [...prev];
@@ -317,7 +358,7 @@ export function useQueue(
     queuePanelRef, dragIndexRef,
     playTracks, enqueueTracks,
     playNext, playPrevious,
-    removeFromQueue, moveInQueue, clearQueue,
+    removeFromQueue, removeMultiple, moveInQueue, moveToTop, moveToBottom, clearQueue,
     toggleQueueMode, playNextInQueue, addToQueue, addToQueueAndPlay,
     peekNext, advanceIndex,
     playlistName, savePlaylist, loadPlaylist,


### PR DESCRIPTION
## Summary

- Add Ctrl/Cmd+Click toggle and Shift+Click range selection to the playlist (QueuePanel)
- Right-click context menu with Play, Remove, Move to top, Move to bottom for selected tracks
- Batch queue operations (`removeMultiple`, `moveToTop`, `moveToBottom`) with proper queueIndex adjustment
- Visual selection styling matching existing track list pattern

Closes #34

## Test plan

- [ ] Open playlist panel, Ctrl+Click multiple tracks — verify they highlight
- [ ] Shift+Click to select a range — verify contiguous range highlights
- [ ] Right-click on selected tracks — verify context menu shows Play/Remove/Move to top/Move to bottom
- [ ] Remove N tracks — verify tracks removed and playback index adjusts correctly
- [ ] Move to top/bottom — verify tracks reorder and current track index stays correct
- [ ] Escape key clears selection
- [ ] Plain click selects single item and plays it

🤖 Generated with [Claude Code](https://claude.com/claude-code)