### PR TITLE
feat: add waveform analysis and view inside the seek bar (#99)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1550,6 +1550,23 @@ fn resolve_cover_url(db: &Arc<Database>, track: &Track, collection_id: i64) -> O
     None
 }
 
+#[tauri::command]
+pub fn get_cached_waveform(state: State<'_, AppState>, track_id: i64) -> Option<Vec<f32>> {
+    let path = state.app_dir.join("waveforms").join(format!("{}.json", track_id));
+    let data = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+#[tauri::command]
+pub fn cache_waveform(state: State<'_, AppState>, track_id: i64, peaks: Vec<f32>) -> Result<(), String> {
+    let dir = state.app_dir.join("waveforms");
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let path = dir.join(format!("{}.json", track_id));
+    let json = serde_json::to_string(&peaks).map_err(|e| e.to_string())?;
+    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -89,6 +89,8 @@ fn get_invoke_handler() -> impl Fn(tauri::ipc::Invoke) -> bool + Send + Sync + '
         commands::tidal_download_preview,
         commands::confirm_track_upgrade,
         commands::cancel_track_upgrade,
+        commands::get_cached_waveform,
+        commands::cache_waveform,
     ]
 }
 
@@ -158,6 +160,8 @@ fn get_invoke_handler() -> impl Fn(tauri::ipc::Invoke) -> bool + Send + Sync + '
         commands::tidal_download_preview,
         commands::confirm_track_upgrade,
         commands::cancel_track_upgrade,
+        commands::get_cached_waveform,
+        commands::cache_waveform,
     ]
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { useSessionLog } from "./hooks/useSessionLog";
 import { useAppUpdater } from "./hooks/useAppUpdater";
 import { useMiniMode } from "./hooks/useMiniMode";
 import { useVideoSplit } from "./hooks/useVideoSplit";
+import { useWaveform } from "./hooks/useWaveform";
 import { useGlobalShortcuts } from "./hooks/useGlobalShortcuts";
 import { WindowControls } from "./components/WindowControls";
 
@@ -75,6 +76,13 @@ function App() {
   trackVideoHistoryRef.current = trackVideoHistory;
   const advanceIndexRef = useRef<() => void>(() => {});
   const playback = usePlayback(restoredRef, peekNextRef, crossfadeSecsRef, advanceIndexRef, trackVideoHistoryRef);
+  const waveformPeaks = useWaveform(
+    playback.currentTrack?.id ?? null,
+    playback.currentTrack?.file_size ?? null,
+    playback.currentTrack?.subsonic_id ?? null,
+    playback.currentTrack ? isVideoTrack(playback.currentTrack) : false,
+    playback.currentAssetUrl,
+  );
   const tidalStreamUrls = useRef<Map<number, string>>(new Map());
   const handlePlayWithTidal = useCallback((track: Track) => {
     const url = tidalStreamUrls.current.get(track.id);
@@ -2514,6 +2522,7 @@ function App() {
             onDoubleClick={playback.toggleFullscreen}
           />
           <FullscreenControls
+            waveformPeaks={waveformPeaks}
             currentTrack={playback.currentTrack}
             playing={playback.playing}
             positionSecs={playback.positionSecs}
@@ -2691,6 +2700,7 @@ function App() {
       )}
 
       <NowPlayingBar
+        waveformPeaks={waveformPeaks}
         currentTrack={playback.currentTrack}
         playing={playback.playing}
         positionSecs={playback.positionSecs}

--- a/src/components/FullscreenControls.tsx
+++ b/src/components/FullscreenControls.tsx
@@ -4,8 +4,10 @@ import type { Track } from "../types";
 import type { AutoContinueWeights } from "../hooks/useAutoContinue";
 import { formatDuration } from "../utils";
 import { AutoContinuePopover } from "./AutoContinuePopover";
+import { WaveformSeekBar } from "./WaveformSeekBar";
 
 interface FullscreenControlsProps {
+  waveformPeaks: number[] | null;
   currentTrack: Track | null;
   playing: boolean;
   positionSecs: number;
@@ -42,6 +44,7 @@ interface FullscreenControlsProps {
 const IDLE_TIMEOUT = 3000;
 
 export function FullscreenControls({
+  waveformPeaks,
   currentTrack, playing,
   positionSecs, durationSecs, scrobbled,
   volume, queueMode,
@@ -143,7 +146,16 @@ export function FullscreenControls({
           onSeek(pct * durationSecs);
         }}
       >
-        <div className="fs-seek-fill" style={{ width: `${durationSecs > 0 ? (positionSecs / durationSecs) * 100 : 0}%` }} />
+        {waveformPeaks ? (
+          <WaveformSeekBar
+            peaks={waveformPeaks}
+            progress={durationSecs > 0 ? positionSecs / durationSecs : 0}
+            accentColor="rgba(83, 168, 255, 0.8)"
+            dimColor="rgba(255, 255, 255, 0.2)"
+          />
+        ) : (
+          <div className="fs-seek-fill" style={{ width: `${durationSecs > 0 ? (positionSecs / durationSecs) * 100 : 0}%` }} />
+        )}
         <span className="fs-seek-time fs-seek-elapsed">{formatDuration(positionSecs)}</span>
         <span className="fs-seek-time fs-seek-total">
           {formatDuration(durationSecs)}

--- a/src/components/NowPlayingBar.tsx
+++ b/src/components/NowPlayingBar.tsx
@@ -5,6 +5,7 @@ import type { Track } from "../types";
 import type { AutoContinueWeights } from "../hooks/useAutoContinue";
 import { formatDuration } from "../utils";
 import { AutoContinuePopover } from "./AutoContinuePopover";
+import { WaveformSeekBar } from "./WaveformSeekBar";
 
 const mod = navigator.platform.includes("Mac") ? "\u2318" : "Ctrl+";
 
@@ -30,6 +31,7 @@ const shortcuts = [
 
 
 interface NowPlayingBarProps {
+  waveformPeaks: number[] | null;
   currentTrack: Track | null;
   playing: boolean;
   positionSecs: number;
@@ -64,6 +66,7 @@ interface NowPlayingBarProps {
 }
 
 export function NowPlayingBar({
+  waveformPeaks,
   currentTrack, playing,
   positionSecs, durationSecs, scrobbled,
   volume, queueMode,
@@ -120,7 +123,16 @@ export function NowPlayingBar({
           onSeek(pct * durationSecs);
         }}
       >
-        <div className="now-seek-fill" style={{ width: `${durationSecs > 0 ? (positionSecs / durationSecs) * 100 : 0}%` }} />
+        {waveformPeaks ? (
+          <WaveformSeekBar
+            peaks={waveformPeaks}
+            progress={durationSecs > 0 ? positionSecs / durationSecs : 0}
+            accentColor="rgba(83, 168, 255, 0.7)"
+            dimColor="rgba(255, 255, 255, 0.15)"
+          />
+        ) : (
+          <div className="now-seek-fill" style={{ width: `${durationSecs > 0 ? (positionSecs / durationSecs) * 100 : 0}%` }} />
+        )}
         <span className="now-seek-time now-seek-elapsed">{formatDuration(positionSecs)}</span>
         <span className="now-seek-time now-seek-total">
           {formatDuration(durationSecs)}

--- a/src/components/WaveformSeekBar.tsx
+++ b/src/components/WaveformSeekBar.tsx
@@ -1,0 +1,79 @@
+import { useRef, useEffect, useCallback } from "react";
+
+interface WaveformSeekBarProps {
+  peaks: number[];
+  progress: number; // 0..1
+  accentColor: string;
+  dimColor: string;
+}
+
+export function WaveformSeekBar({ peaks, progress, accentColor, dimColor }: WaveformSeekBarProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const frameRef = useRef<number>(0);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || peaks.length === 0) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+
+    if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      ctx.scale(dpr, dpr);
+    }
+
+    ctx.clearRect(0, 0, w, h);
+
+    const barCount = peaks.length;
+    const totalBarWidth = w / barCount;
+    const gap = Math.max(0.5, totalBarWidth * 0.2);
+    const barWidth = totalBarWidth - gap;
+    const minBarHeight = 2;
+    const maxBarHeight = h * 0.85;
+    const playedX = progress * w;
+
+    for (let i = 0; i < barCount; i++) {
+      const x = i * totalBarWidth + gap / 2;
+      const barH = Math.max(minBarHeight, peaks[i] * maxBarHeight);
+      const y = (h - barH) / 2;
+
+      ctx.fillStyle = x + barWidth <= playedX ? accentColor : dimColor;
+      ctx.fillRect(x, y, barWidth, barH);
+    }
+  }, [peaks, progress, accentColor, dimColor]);
+
+  useEffect(() => {
+    cancelAnimationFrame(frameRef.current);
+    frameRef.current = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(frameRef.current);
+  }, [draw]);
+
+  useEffect(() => {
+    const onResize = () => {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = requestAnimationFrame(draw);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [draw]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        pointerEvents: "none",
+      }}
+    />
+  );
+}

--- a/src/hooks/usePlayback.ts
+++ b/src/hooks/usePlayback.ts
@@ -30,6 +30,7 @@ export function usePlayback(
   const scrobbledRef = useRef(false);
   const [scrobbled, setScrobbled] = useState(false);
   const [playbackError, setPlaybackError] = useState<string | null>(null);
+  const [currentAssetUrl, setCurrentAssetUrl] = useState<string | null>(null);
   const playStartedAtRef = useRef(0);
 
   // Preload state (refs for use in event handlers without stale closures)
@@ -348,6 +349,7 @@ export function usePlayback(
     }
 
     setCurrentTrack(track);
+    setCurrentAssetUrl(src);
     setPositionSecs(0);
     setDurationSecs(track.duration_secs ?? 0);
     scrobbledRef.current = false;
@@ -393,6 +395,7 @@ export function usePlayback(
       const src = track.subsonic_id ? pathOrUrl : convertFileSrc(pathOrUrl);
 
       setCurrentTrack(track);
+      setCurrentAssetUrl(src);
       setPositionSecs(position);
       setDurationSecs(track.duration_secs ?? 0);
       scrobbledRef.current = false;
@@ -437,6 +440,7 @@ export function usePlayback(
     }
     setPlaying(false);
     setPositionSecs(0);
+    setCurrentAssetUrl(null);
   }
 
   function onMediaError(e: React.SyntheticEvent<HTMLAudioElement | HTMLVideoElement>) {
@@ -572,6 +576,7 @@ export function usePlayback(
 
   return {
     currentTrack, setCurrentTrack,
+    currentAssetUrl,
     playing, setPlaying, scrobbled,
     positionSecs, setPositionSecs,
     durationSecs, setDurationSecs,

--- a/src/hooks/useWaveform.ts
+++ b/src/hooks/useWaveform.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+const NUM_BUCKETS = 200;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+export function useWaveform(
+  trackId: number | null,
+  fileSize: number | null,
+  subsonicId: string | null,
+  isVideo: boolean,
+  assetUrl: string | null,
+): number[] | null {
+  const [peaks, setPeaks] = useState<number[] | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    setPeaks(null);
+
+    if (!trackId) return;
+    if (subsonicId) return;
+    if (isVideo) return;
+    if (fileSize && fileSize > MAX_FILE_SIZE) return;
+
+    let cancelled = false;
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    (async () => {
+      // Check cache first
+      try {
+        const cached = await invoke<number[] | null>("get_cached_waveform", { trackId });
+        if (cancelled) return;
+        if (cached && cached.length > 0) {
+          setPeaks(cached);
+          return;
+        }
+      } catch {
+        // Cache miss or read error — continue to analyze
+      }
+
+      if (!assetUrl) return;
+
+      // Fetch + decode + compute peaks
+      try {
+        const response = await fetch(assetUrl, { signal: controller.signal });
+        if (cancelled) return;
+        const arrayBuffer = await response.arrayBuffer();
+        if (cancelled) return;
+
+        const audioCtx = new OfflineAudioContext(1, 1, 44100);
+        const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+        if (cancelled) return;
+
+        const channelData = audioBuffer.getChannelData(0);
+        const bucketSize = Math.floor(channelData.length / NUM_BUCKETS);
+        if (bucketSize === 0) return;
+
+        const result: number[] = new Array(NUM_BUCKETS);
+        let maxPeak = 0;
+        for (let i = 0; i < NUM_BUCKETS; i++) {
+          let max = 0;
+          const start = i * bucketSize;
+          const end = Math.min(start + bucketSize, channelData.length);
+          for (let j = start; j < end; j++) {
+            const abs = Math.abs(channelData[j]);
+            if (abs > max) max = abs;
+          }
+          result[i] = max;
+          if (max > maxPeak) maxPeak = max;
+        }
+
+        // Normalize to 0..1
+        if (maxPeak > 0) {
+          for (let i = 0; i < NUM_BUCKETS; i++) {
+            result[i] /= maxPeak;
+          }
+        }
+
+        if (cancelled) return;
+        setPeaks(result);
+
+        // Cache for next time (fire-and-forget)
+        invoke("cache_waveform", { trackId, peaks: result }).catch(() => {});
+      } catch (e) {
+        if (!cancelled) {
+          console.debug("Waveform analysis failed:", e);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [trackId, fileSize, subsonicId, isVideo, assetUrl]);
+
+  return peaks;
+}


### PR DESCRIPTION
## Summary
- Analyze audio files using Web Audio API (`OfflineAudioContext.decodeAudioData`) and display a waveform visualization in the seek bar
- Cache waveform data as JSON files in the backend (`{app_dir}/waveforms/{track_id}.json`) for instant display on subsequent plays
- Waveform renders in both the NowPlayingBar and FullscreenControls seek bars via a shared `WaveformSeekBar` canvas component
- Graceful degradation: plain seek bar shown for video tracks, remote/subsonic tracks, files >10MB, or when decoding fails

Closes #99

## Test plan
- [ ] Play a local audio file <10MB — waveform appears in seek bar
- [ ] Play the same track again — waveform loads instantly from cache
- [ ] Play a video track — plain seek bar (no waveform)
- [ ] Play a file >10MB — plain seek bar
- [ ] Click on waveform to seek — works correctly
- [ ] Enter fullscreen mode — waveform appears there too
- [ ] Rapid track skipping — no errors, waveforms load/cancel cleanly

Generated with [Claude Code](https://claude.com/claude-code)