### PR TITLE
feat: scroll to playing track when playlist is expanded (#105)

### DIFF
--- a/src/components/QueuePanel.tsx
+++ b/src/components/QueuePanel.tsx
@@ -89,6 +89,17 @@ export function QueuePanel({
   // Clear selection when queue changes (add/remove/reorder)
   useEffect(() => { setSelectedIndices(new Set()); }, [queue]);
 
+  // Scroll to currently playing track when panel opens or un-collapses
+  useEffect(() => {
+    if (!collapsed && queueIndex >= 0 && queuePanelRef.current) {
+      requestAnimationFrame(() => {
+        const list = queuePanelRef.current?.querySelector(".queue-list");
+        const item = list?.children[queueIndex] as HTMLElement | undefined;
+        item?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      });
+    }
+  }, [collapsed]);
+
   // Auto-approve countdown for duplicate warning
   useEffect(() => {
     if (!pendingEnqueue) { setCountdown(AUTO_APPROVE_SECS); return; }

--- a/src/hooks/useQueue.ts
+++ b/src/hooks/useQueue.ts
@@ -38,10 +38,12 @@ export function useQueue(
 
   // Auto-scroll queue panel to current track
   useEffect(() => {
-    if (showQueue && queueIndex >= 0 && queuePanelRef.current) {
-      const list = queuePanelRef.current.querySelector(".queue-list");
-      const item = list?.children[queueIndex] as HTMLElement | undefined;
-      item?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    if (showQueue && queueIndex >= 0) {
+      requestAnimationFrame(() => {
+        const list = queuePanelRef.current?.querySelector(".queue-list");
+        const item = list?.children[queueIndex] as HTMLElement | undefined;
+        item?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      });
     }
   }, [queueIndex, showQueue]);
 


### PR DESCRIPTION
## Summary
- Scroll the currently playing track into view when the playlist panel is expanded (shown or un-collapsed)
- Fix timing issue in existing auto-scroll by using `requestAnimationFrame` to wait for DOM render
- Add scroll-on-uncollapse in `QueuePanel` component

Closes #105

## Test plan
- [ ] Open app with a long playlist and play a track deep in the list
- [ ] Hide the playlist panel, then re-open it — playing track should scroll into view
- [ ] Collapse the playlist to the thin strip, then expand it — playing track should scroll into view
- [ ] Verify auto-scroll still works when changing tracks while the panel is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)