### PR TITLE
Replace playlist remove button with locate track

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3154,6 +3154,9 @@ function App() {
           onCancelEnqueue={() => setPendingEnqueue(null)}
           onPlay={(track, index) => { queueHook.setQueueIndex(index); playback.handlePlay(track); }}
           onRemove={queueHook.removeFromQueue}
+          onLocateTrack={(track) => {
+            if (track.artist_id) library.handleLocateTrack(track.id, track.artist_id, track.album_id);
+          }}
           onMoveMultiple={queueHook.moveMultiple}
           onClear={queueHook.clearQueue}
           onSavePlaylist={queueHook.savePlaylist}

--- a/src/components/QueuePanel.tsx
+++ b/src/components/QueuePanel.tsx
@@ -58,6 +58,7 @@ interface QueuePanelProps {
   onCancelEnqueue: () => void;
   onPlay: (track: Track, index: number) => void;
   onRemove: (index: number) => void;
+  onLocateTrack?: (track: Track) => void;
   onMoveMultiple: (indices: number[], targetIndex: number) => void;
   onClear: () => void;
   onSavePlaylist: () => void;
@@ -73,7 +74,7 @@ const AUTO_APPROVE_SECS = 10;
 export function QueuePanel({
   queue, queueIndex, queuePanelRef, playlistName,
   pendingEnqueue, onAllowAll, onSkipDuplicates, onCancelEnqueue,
-  onPlay, onRemove, onMoveMultiple, onClear, onSavePlaylist, onLoadPlaylist, onContextMenu, externalDropTarget,
+  onPlay, onRemove: _onRemove, onLocateTrack, onMoveMultiple, onClear, onSavePlaylist, onLoadPlaylist, onContextMenu, externalDropTarget,
   collapsed, onToggleCollapsed,
 }: QueuePanelProps) {
   const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
@@ -311,13 +312,15 @@ export function QueuePanel({
               <span className="queue-item-artist">{t.artist_name || "Unknown"}</span>
             </div>
             <span className="queue-item-duration">{formatDuration(t.duration_secs)}</span>
-            <button
-              className="queue-item-remove"
-              onClick={(e) => { e.stopPropagation(); onRemove(i); }}
-              title="Remove"
-            >
-              {"\u00D7"}
-            </button>
+            {onLocateTrack && t.artist_id && (
+              <button
+                className="queue-item-remove"
+                onClick={(e) => { e.stopPropagation(); onLocateTrack(t); }}
+                title="Locate Track"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+              </button>
+            )}
           </div>
         ))}
         {queue.length === 0 && (


### PR DESCRIPTION
## Summary
- Replaces the × remove button on each playlist/queue item with a magnifying glass "Locate Track" button
- Clicking it navigates to the track in the library view using the existing `handleLocateTrack` mechanism
- Track removal is still available via the right-click context menu

## Test plan
- [ ] Open the playlist/queue panel with tracks
- [ ] Verify each track shows a magnifying glass icon instead of ×
- [ ] Click the icon and confirm it navigates to the track in the library
- [ ] Right-click a queue item and verify "Remove" is still available in the context menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)